### PR TITLE
Fix gutter colours

### DIFF
--- a/styles/colors.less
+++ b/styles/colors.less
@@ -1,8 +1,8 @@
 
 // Config -----------------------------------
 @syntax-hue:          228;
-@syntax-saturation:   13%;
-@syntax-brightness:   19%;
+@syntax-saturation:   1%;
+@syntax-brightness:   98%;
 
 
 // Monochrome -----------------------------------
@@ -26,6 +26,6 @@
 // Base colors -----------------------------------
 @syntax-fg:     @mono-1;
 @syntax-bg:     hsl(@syntax-hue, @syntax-saturation, @syntax-brightness);
-@syntax-gutter: darken(@syntax-fg, 36%);
+@syntax-gutter: darken(@syntax-bg, 36%);
 @syntax-guide:  fade(@syntax-fg, 15%);
-@syntax-accent: hsl(@syntax-hue, 100%, 100% );
+@syntax-accent: hsl(@syntax-hue, 100%, 66% );


### PR DESCRIPTION
I just copied the colours from the `one-light-syntax` theme.

---

Before:

![before](https://cloud.githubusercontent.com/assets/5394551/26236134/0d86b676-3c6f-11e7-99a7-22ac9545b409.png)

After:

![after](https://cloud.githubusercontent.com/assets/5394551/26236136/12d50fec-3c6f-11e7-912d-a903626af445.png)

